### PR TITLE
fix: clear listeners after sending destroy event, not before

### DIFF
--- a/src/3d/object3d.js
+++ b/src/3d/object3d.js
@@ -416,14 +416,14 @@ export default class Object3D extends Listenable {
 			this.parent.removeChild(this);
 		}
 
-		this.clearListeners();
-
 		for (let child of this._children) {
 			this.removeChild(child);
 			child.destroy();
 		}
 
 		this.notify('destroy');
+
+		this.clearListeners();
 	}
 
 	/**


### PR DESCRIPTION
If listeners are cleared before sending the 'destroy' event, the event is useless, because nobody is listening for it anymore.

This change has the side effect of also sending a 'remove' event for each child when a parent is destroyed, since that had also been done after clearing listeners but before sending the 'destroy' event.